### PR TITLE
Add terraform config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.terraform.lock.hcl

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -75,7 +75,7 @@ resource "google_storage_bucket" "rethinkdb_backup_bucket" {
   uniform_bucket_level_access = true
 }
 
-resource "google_service_account" "rethinkdb_service_account" {
+resource "google_service_account" "rethinkdb_admin_service_account" {
   account_id   = "rethinkdb-admin"
   display_name = "RethinkDB Storage Admin Service Account"
   project      = var.project_id
@@ -86,6 +86,18 @@ resource "google_storage_bucket_iam_binding" "rethinkdb_bucket_iam_binding" {
   role   = "roles/storage.objectAdmin"
 
   members = [
-    "serviceAccount:${google_service_account.rethinkdb_service_account.email}",
+    "serviceAccount:${google_service_account.rethinkdb_admin_service_account.email}",
   ]
+}
+
+resource "google_service_account" "rethink_vm_service_account" {
+  account_id   = "rethinkdb-vm-admin"
+  display_name = "RethinkDB VM Service Account"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "compute_admin" {
+  project = var.project_id
+  role    = "roles/compute.admin"
+  member  = "serviceAccount:${google_service_account.rethink_vm_service_account.email}"
 }

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -1,0 +1,87 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+// VM Instance
+resource "google_compute_instance" "rethinkdb_instance" {
+  name         = "rethinkdb-vm"
+  machine_type = "n1-standard-2" // TODO
+  zone         = var.zone
+  project      = var.project_id
+
+  boot_disk {
+    initialize_params {
+      size = 10
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+}
+
+// load balancer - set create_load_balancer to True to setup load balancer
+resource "google_compute_backend_service" "rethinkdb_backend_service" {
+  count                           = var.create_load_balancer ? 1 : 0
+  name                            = "rethinkdb-backend-service"
+  project                         = var.project_id
+  protocol                        = "TCP"
+  timeout_sec                     = 10
+  port_name                       = "rethinkdb"
+  enable_cdn                      = false
+  connection_draining_timeout_sec = 300
+
+  backend {
+    group = google_compute_instance.rethinkdb_instance.self_link
+  }
+}
+
+resource "google_compute_health_check" "rethinkdb_health_check" {
+  count              = var.create_load_balancer ? 1 : 0
+  name               = "rethinkdb-health-check"
+  check_interval_sec = 5
+  timeout_sec        = 5
+  tcp_health_check {
+    port = 8080
+  }
+}
+
+resource "google_compute_target_pool" "rethinkdb_target_pool" {
+  count         = var.create_load_balancer ? 1 : 0
+  name          = "rethinkdb-target-pool"
+  region        = var.region
+  project       = var.project_id
+  instances     = [google_compute_instance.rethinkdb_instance.self_link]
+  health_checks = [google_compute_health_check.rethinkdb_health_check[count.index].self_link]
+}
+
+resource "google_compute_forwarding_rule" "rethinkdb_forwarding_rule" {
+  count      = var.create_load_balancer ? 1 : 0
+  name       = "rethinkdb-forwarding-rule"
+  region     = var.region
+  project    = var.project_id
+  target     = google_compute_target_pool.rethinkdb_target_pool[count.index].self_link
+  port_range = "8080"
+}
+
+// storage bucket
+resource "google_storage_bucket" "rethinkdb_backup_bucket" {
+  name                        = "rethinkdb-backups"
+  project                     = var.project_id
+  location                    = var.region
+  uniform_bucket_level_access = true
+}
+
+resource "google_service_account" "rethinkdb_service_account" {
+  account_id   = "rethinkdb-admin"
+  display_name = "RethinkDB Service Account"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "rethinkdb_service_account_permissions" {
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.rethinkdb_service_account.email}"
+}

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -29,6 +29,19 @@ resource "google_compute_subnetwork" "rethinkdb_subnet" {
   network       = google_compute_network.rethinkdb_network.self_link
 }
 
+// Firewall Rule
+resource "google_compute_firewall" "iap_firewall" {
+  name    = "iap-tcp-ingress"
+  network = google_compute_network.rethinkdb_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"] //TODO update as required
+}
+
 // Static IP Address
 resource "google_compute_address" "rethinkdb_static_ip" {
   name         = "rethinkdb-static-ip"

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  default = "parabol-bp-roshan-rathod"
+}
+
+variable "region" {
+  default = "us-central1" // TODO 
+}
+
+variable "zone" {
+  default = "us-central1-a" // TODO 
+}
+
+variable "create_load_balancer" {
+  description = "Flag to indicate whether to create the load balancer"
+  default     = true
+}

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -10,6 +10,10 @@ variable "zone" {
   default = "us-central1-a" // TODO 
 }
 
+variable "disk_size" {
+  default = "10"
+}
+
 variable "create_load_balancer" {
   description = "Flag to indicate whether to create the load balancer"
   default     = true


### PR DESCRIPTION
Terraform confg for rethinkdb instance, optional load balancer,GCS bucket, IAM and Service account

## Initial Setup:

To test, you need to install terraform CLI and gcloudCLI

- [Install terraform locally](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)

- Install[gcloud cli](https://cloud.google.com/sdk/docs/install) to connect with the GCP project locally so you can run terraform commands

- Run `gcloud init` and login to GCP and select the project

- Run `gcloud auth application-default login` to use your credentials for terraform