### PR TITLE
Setup TLS cert on rethink db

### DIFF
--- a/Ansible/playbooks/deploy_rethinkdb.yaml
+++ b/Ansible/playbooks/deploy_rethinkdb.yaml
@@ -62,6 +62,13 @@
         mode: '0600'
       become: true
 
+    - name: Copy certs to VM
+      copy:
+        src: certs
+        dest: /home/rethinkdb/certs
+        mode: '0600'
+      become: true
+
     - name: Stop and remove existing containers
       command: docker-compose -f /home/rethinkdb/docker-compose.yaml down
       become: true

--- a/Ansible/playbooks/docker-compose.yaml.j2
+++ b/Ansible/playbooks/docker-compose.yaml.j2
@@ -3,13 +3,18 @@ version: "3.7"
 services:
   rethinkdb_main:
     image: {{ rethinkdb_image }}
-    command: rethinkdb --bind all --server-tag rethinkdb_main
+    command: rethinkdb --bind all --server-tag rethinkdb_main --http-tls-key /data/certs/key.pem --http-tls-cert /data/certs/cert.pem
     ports:
       - "8080:8080"
       - "29015:29015"
       - "28015:28015"
     volumes:
-      - rethinkdb-data:/data/rethinkdb
+      - type: bind
+        source: certs
+        target: /data
+      - type: volume
+        source: rethinkdb-data
+        target: /data/rethinkdb
     networks:
       - parabol-network
 


### PR DESCRIPTION
Generated self signed cert on local machine. Copied files onto VM, mounted with docker to enable TLS connection.

Guide here : [Secure your cluster](https://rethinkdb.com/docs/security/)